### PR TITLE
Add fallbacks for GPU stats

### DIFF
--- a/examples/nvidia_check.rs
+++ b/examples/nvidia_check.rs
@@ -1,0 +1,44 @@
+fn main() {
+    // this script was mainly a sanity check to see which fields are available on my GPU
+    // run with cargo run --example nvidia_check
+    match nvml_wrapper::Nvml::init() {
+        Ok(nvml) => {
+            println!("NVML init OK");
+            println!("Device count: {:?}", nvml.device_count());
+            match nvml.device_by_index(0) {
+                Ok(dev) => {
+                    println!("Device 0 name: {:?}", dev.name());
+                    println!(
+                        "Temperature: {:?}",
+                        dev.temperature(
+                            nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu
+                        )
+                    );
+                    println!("Memory: {:?}", dev.memory_info());
+                    println!("Utilization: {:?}", dev.utilization_rates());
+                    println!(
+                        "Power limit (power_management_limit): {:?}",
+                        dev.power_management_limit()
+                    );
+                    println!(
+                        "Power limit (enforced_power_limit): {:?}",
+                        dev.enforced_power_limit()
+                    );
+                    println!(
+                        "Power limit (power_management_limit_default): {:?}",
+                        dev.power_management_limit_default()
+                    );
+                    println!(
+                        "Power limit (power_management_limit_constraints): {:?}",
+                        dev.power_management_limit_constraints()
+                    );
+                    println!("Power usage: {:?}", dev.power_usage());
+                    println!("Fan speed: {:?}", dev.fan_speed(0));
+                    println!("Number of fans: {:?}", dev.num_fans());
+                }
+                Err(e) => println!("device_by_index(0) error: {:?}", e),
+            }
+        }
+        Err(e) => println!("NVML init error: {:?}", e),
+    }
+}

--- a/src/data/gpu.rs
+++ b/src/data/gpu.rs
@@ -11,7 +11,7 @@ pub struct GpuSnapshot {
     pub utilization: u32,
     pub max_power: u32,
     pub power_usage: u32,
-    pub fan_speed: u32,
+    pub fan_speed: Option<u32>,
 }
 
 impl GpuSnapshot {
@@ -25,9 +25,15 @@ impl GpuSnapshot {
             max_memory: memory_info.total,
             used_memory: memory_info.used,
             utilization: device.utilization_rates()?.gpu,
-            max_power: device.power_management_limit()?,
+            // previous behaviour was power management first
+            // enforced appears on laptops
+            max_power: device
+                .power_management_limit()
+                .or_else(|_| device.enforced_power_limit())
+                .unwrap_or(0),
             power_usage: device.power_usage()?,
-            fan_speed: device.fan_speed(0)?,
+            // some devices may not have fans, so we default to 0 if it fails?
+            fan_speed: device.fan_speed(0).ok(),
         })
     }
 }

--- a/src/data/gpu.rs
+++ b/src/data/gpu.rs
@@ -25,14 +25,11 @@ impl GpuSnapshot {
             max_memory: memory_info.total,
             used_memory: memory_info.used,
             utilization: device.utilization_rates()?.gpu,
-            // previous behaviour was power management first
-            // enforced appears on laptops
             max_power: device
                 .power_management_limit()
                 .or_else(|_| device.enforced_power_limit())
                 .unwrap_or(0),
             power_usage: device.power_usage()?,
-            // some devices may not have fans, so we default to 0 if it fails?
             fan_speed: device.fan_speed(0).ok(),
         })
     }

--- a/src/widgets/gpu.rs
+++ b/src/widgets/gpu.rs
@@ -34,7 +34,10 @@ impl<'a> Widget for GpuWidget<'a> {
         )));
 
         spans.push(Span::styled("   FAN:", Style::default().fg(Color::Cyan)));
-        spans.push(Span::raw(format!("  {:.0}%", self.data.fan_speed)));
+        match self.data.fan_speed {
+            Some(fan_speed) => spans.push(Span::raw(format!("  {:.0}%", fan_speed))),
+            None => spans.push(Span::raw("  N/A")),
+        }
 
         let mut lines = vec![Line::from(spans).alignment(Alignment::Left)];
 

--- a/tests/test_large.rs
+++ b/tests/test_large.rs
@@ -36,7 +36,7 @@ fn gpu() -> GpuSnapshot {
         utilization: 50,
         max_power: 500,
         power_usage: 250,
-        fan_speed: 50,
+        fan_speed: Some(50),
     }
 }
 


### PR DESCRIPTION
When testing with the example script below I have noticed that on a laptop GPU:

```
Power limit (power_management_limit): Err(NotSupported)
Power limit (enforced_power_limit): Ok(100000)
Power limit (power_management_limit_default): Ok(100000)
...
Fan speed: Err(InvalidArg)
```
Resulting in the GPU not showing

On a H100:
```
Fan speed: Err(InvalidArg)
```

## Changes made

1. Check `power_management_limit` first, then fallback to `enforced_power_limit`, lastly unwrap to 0. This can be converted to Option as well. 
2. Fan speed is changed to Option rather than unwrap to 0, because some models of consumer fans can drop to 0, and we don't want a false reading. 
3. For fan speed, NA is shown if None, percentage if Some. 


Closes #53 